### PR TITLE
Validated Traverse Recipe

### DIFF
--- a/src/main/java/arrow/ChangeValidatedLambda.java
+++ b/src/main/java/arrow/ChangeValidatedLambda.java
@@ -58,6 +58,8 @@ public class ChangeValidatedLambda extends Recipe {
                     m = m.withName(m.getName().withSimpleName("mapOrAccumulate"));
                     m = m.withMethodType(methodType.withName("mapOrAccumulate"));
                     m = (J.MethodInvocation) new AppendBindFunction().visitMethodInvocation(m, executionContext);
+                    maybeAddImport("arrow.core.mapOrAccumulate", false);
+                    maybeRemoveImport("arrow.core.traverse");
                 }
                 return m;
             }

--- a/src/test/java/arrow/ValidatedLambdaToEitherTest.java
+++ b/src/test/java/arrow/ValidatedLambdaToEitherTest.java
@@ -82,6 +82,41 @@ public class ValidatedLambdaToEitherTest implements RewriteTest {
 
     @Test
     @Disabled("FIXME: Not supported in ChangeValidatedLambda yet")
+    void validatedInlineFunction() {
+        rewriteRun(
+          kotlin(
+            """
+              package com.yourorg
+              
+              import arrow.core.Validated
+              import arrow.core.traverse
+              
+              fun foo() {
+                  listOf(1, 2, 3).traverse {
+                      val res: Validated<String, Int> = it.valid()
+                      res
+                  }
+              }
+              """,
+            """
+              package com.yourorg
+              
+              import arrow.core.Validated
+              import arrow.core.mapOrAccumulate
+              
+              fun foo() {
+                  listOf(1, 2, 3).mapOrAccumulate {
+                      val res: Validated<String, Int> = it.valid()
+                      res.bind()
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Disabled("FIXME: Not supported in ChangeValidatedLambda yet")
     void validatedIfExpressionLambda() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
Supports simple cases, but harder cases are not yet supported.

- [ ] Add support for inline functions that return `Validated` inside the lambda
- [ ] Investigate what change is required in rewrite-kotlin